### PR TITLE
update release notes after bumping go

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -2,6 +2,14 @@
 title: Service Backups for PCF Release Notes
 owner: London Services Enablement
 ---
+## <a id="18116x"></a>v18.1.16
+
+**Release Date:** December 18, 2018
+
+### Fixed Issues
+
+- Updates golang to v1.11.4.
+
 ## <a id="18115x"></a>v18.1.15
 
 **Release Date:** October 5, 2018


### PR DESCRIPTION
Mentioning v18.1.16 is purely a go version bump